### PR TITLE
Separate user constants into dedicated files and restore batch launcher

### DIFF
--- a/ytAutoDownload.bat
+++ b/ytAutoDownload.bat
@@ -1,0 +1,1 @@
+﻿powershell -ExecutionPolicy Bypass -Command "& '%~dpn0.ps1'"

--- a/ytAutoDownload_constants.ps1
+++ b/ytAutoDownload_constants.ps1
@@ -1,12 +1,4 @@
-#User defined values
-$ARCHIVE_TXT_DIR = ""
-$COOKIES_DIR = ""
-$ROOT_DIR_MONITORED = ""
-$ROOT_DIR_MUSIC_VIDEO = ""
-$ROOT_DIR_YOUTUBE = ""
-$ROOT_DIR_YOUTUBE_SHORTS = ""
-
-#Constant values
+﻿#Constant values
 $SUBTITLES_BOTH = "BOTH"
 $SUBTITLES_DOWNLOAD = "DOWNLOAD"
 $SUBTITLES_EMBED = "EMBED"
@@ -26,13 +18,4 @@ $SUBTITLES_KEY = "SUBTITLES"
 $SUBTITLES_REQUIRED_KEY = "SUBTITLES_REQUIRED"
 $URL_KEY = "URL"
 
-#User defined monitored sources
-$monitoredHashArray = @(
-    @{
-        # $LABEL_KEY = "label"
-        # $ARCHIVE_TXT_KEY = "D:\Path_to_archive.txt"
-        # $DIRECTORY_KEY = "D:\Directory_to_Download_to"
-        # $SUBTITLES_KEY = $SUBTITLES_EMBED
-        # $URL_KEY = "URL_to_Download"
-    }
-)
+. $PSScriptRoot\ytAutoDownload_user_constants.ps1

--- a/ytAutoDownload_user_constants.ps1
+++ b/ytAutoDownload_user_constants.ps1
@@ -1,0 +1,18 @@
+﻿#User defined values
+$ARCHIVE_TXT_DIR = ""
+$COOKIES_DIR = ""
+$ROOT_DIR_MONITORED = ""
+$ROOT_DIR_MUSIC_VIDEO = ""
+$ROOT_DIR_YOUTUBE = ""
+$ROOT_DIR_YOUTUBE_SHORTS = ""
+
+#User defined monitored sources
+$monitoredHashArray = @(
+    @{
+        # $LABEL_KEY = "label"
+        # $ARCHIVE_TXT_KEY = "D:\Path_to_archive.txt"
+        # $DIRECTORY_KEY = "D:\Directory_to_Download_to"
+        # $SUBTITLES_KEY = $SUBTITLES_EMBED
+        # $URL_KEY = "URL_to_Download"
+    }
+)

--- a/ytdl_constants.ps1
+++ b/ytdl_constants.ps1
@@ -1,4 +1,4 @@
-$AUDIO_FORMAT_MP3 = "mp3"
+﻿$AUDIO_FORMAT_MP3 = "mp3"
 $AUDIO_FORMAT_PARAMETER = "--audio-format"
 $AUDIO_QUALITY_BEST = 0
 $AUDIO_QUALITY_PARAMETER = "--audio-quality"
@@ -45,13 +45,8 @@ $RESOLUTION_720p = "720p"
 $SKIP_DOWNLOAD_PARAMETER = "--skip-download"
 $SUB_LANG_EN = "en,en-US,en-FmoQciUtYSc"
 $SUB_LANG_PARAMETER = "--sub-lang"
-$VERSION_NUMBER = "1.6"
+$VERSION_NUMBER = "1.7"
 $WRITE_SUBS_PARAMETER = "--write-subs"
 $YOUTUBE_ID_BASE_URL = "https://youtube.com/watch?v="
 
-#User Constants
-#setting cookies from file and browser at the same time could cause issues
-$COOKIES_FILE_PATREON = ""
-$COOKIES_FILE_YOUTUBE = ""
-$COOKIES_BROWSER_DEFAULT = ""
-$DOWNLOAD_DIRECTORY_DEFAULT = ""
+. $PSScriptRoot\ytdl_user_constants.ps1

--- a/ytdl_user_constants.ps1
+++ b/ytdl_user_constants.ps1
@@ -1,0 +1,6 @@
+﻿#User Constants
+#setting cookies from file and browser at the same time could cause issues
+$COOKIES_FILE_PATREON = ""
+$COOKIES_FILE_YOUTUBE = ""
+$COOKIES_BROWSER_DEFAULT = ""
+$DOWNLOAD_DIRECTORY_DEFAULT = ""


### PR DESCRIPTION
- Split user constants from ytdl_constants.ps1 into ytdl_user_constants.ps1
- Split user constants from ytAutoDownload_constants.ps1 into ytAutoDownload_user_constants.ps1
- Constants files now dot-source their user counterparts
- Restored ytAutoDownload.bat batch launcher
- Version bumped to 1.7